### PR TITLE
Switching to terraform-aws-sg-rule-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Using the Repo Source
 
 ```hcl
-github.com/pbs/terraform-aws-ecs-service-module?ref=2.2.2
+github.com/pbs/terraform-aws-ecs-service-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -26,7 +26,7 @@ Integrate this module like so:
 
 ```hcl
 module "service" {
-  source = "github.com/pbs/terraform-aws-ecs-service-module?ref=2.2.2"
+  source = "github.com/pbs/terraform-aws-ecs-service-module?ref=x.y.z"
 
   # Required
   primary_hosted_zone = "example.com"
@@ -47,7 +47,7 @@ module "service" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`2.2.2`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -105,16 +105,11 @@ Below is automatically generated documentation on this Terraform module using [t
 | [aws_route53_record.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_security_group.lb_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.service_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.efs_service_access_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.lb_to_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nlb_service_access_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nlb_service_access_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.service_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.service_to_efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.service_to_memcached](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.service_to_mysql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.service_to_redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.user_to_lb_http_cidrs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.user_to_lb_http_sgs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.user_to_lb_https_cidrs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -155,7 +150,6 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment | `number` | `100` | no |
 | <a name="input_dns_evaluate_target_health"></a> [dns\_evaluate\_target\_health](#input\_dns\_evaluate\_target\_health) | evaluate health of endpoints by querying DNS records | `bool` | `false` | no |
 | <a name="input_efs_mounts"></a> [efs\_mounts](#input\_efs\_mounts) | (optional) efs mount set of objects. Components should include dns\_name, container\_mount\_point, efs\_mount\_point | <pre>set(object({<br>    file_system_id = string<br>    efs_path       = string<br>    container_path = string<br>  }))</pre> | `[]` | no |
-| <a name="input_efs_sg_ids"></a> [efs\_sg\_ids](#input\_efs\_sg\_ids) | EFS Security group IDs | `set(string)` | `[]` | no |
 | <a name="input_enable_circuit_breaker"></a> [enable\_circuit\_breaker](#input\_enable\_circuit\_breaker) | Enables ECS circuit breaker | `bool` | `true` | no |
 | <a name="input_enable_circuit_breaker_rollback"></a> [enable\_circuit\_breaker\_rollback](#input\_enable\_circuit\_breaker\_rollback) | Enables ECS circuit breaker rollback | `bool` | `true` | no |
 | <a name="input_enable_execute_command"></a> [enable\_execute\_command](#input\_enable\_execute\_command) | Enables `ecs exec`. If null, will enable if not on prod | `bool` | `null` | no |
@@ -177,11 +171,9 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_load_balancer_name"></a> [load\_balancer\_name](#input\_load\_balancer\_name) | Load balancer name. Will default to product if not defined. | `string` | `null` | no |
 | <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | Type of load balancer to use. alb, nlb or gateway. | `string` | `"application"` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | The maximum capacity of tasks for this service | `number` | `2` | no |
-| <a name="input_memcached_sg_ids"></a> [memcached\_sg\_ids](#input\_memcached\_sg\_ids) | Memcached Security group IDs | `set(string)` | `[]` | no |
 | <a name="input_memory_reservation"></a> [memory\_reservation](#input\_memory\_reservation) | (optional) memory reservation for task | `number` | `512` | no |
 | <a name="input_mesh_name"></a> [mesh\_name](#input\_mesh\_name) | (optional) the name for the App Mesh this task is associated with. If null, ignored | `string` | `null` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | The minimum capacity of tasks for this service | `number` | `1` | no |
-| <a name="input_mysql_sg_ids"></a> [mysql\_sg\_ids](#input\_mysql\_sg\_ids) | MySQL DB Security group IDs | `set(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the service. Will default to product if not defined. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace. If null, defaults to `var.application-tag`. | `string` | `null` | no |
 | <a name="input_namespace_id"></a> [namespace\_id](#input\_namespace\_id) | Namespace ID. | `string` | `null` | no |
@@ -195,7 +187,6 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_private_hosted_zone"></a> [private\_hosted\_zone](#input\_private\_hosted\_zone) | Name of the private hosted zone for DNS. e.g. private\_hosted\_zone = example.org --> service.example.private. If null, it is assumed that a public hosted zone will be used. | `string` | `null` | no |
 | <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | Specifies whether to propagate the tags from the task definition or the service to the tasks | `string` | `"SERVICE"` | no |
 | <a name="input_public_service"></a> [public\_service](#input\_public\_service) | Service should be provisioned in public subnet. Ignored if subnets defined. | `bool` | `true` | no |
-| <a name="input_redis_sg_ids"></a> [redis\_sg\_ids](#input\_redis\_sg\_ids) | Redis Security group IDs | `set(string)` | `[]` | no |
 | <a name="input_requires_compatibilities"></a> [requires\_compatibilities](#input\_requires\_compatibilities) | (optional) capabilities that the task requires | `set(string)` | <pre>[<br>  "FARGATE"<br>]</pre> | no |
 | <a name="input_restricted_cidr_blocks"></a> [restricted\_cidr\_blocks](#input\_restricted\_cidr\_blocks) | CIDR blocks to receive restricted service access. If empty, no CIDRs will be allowed to connect. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_restricted_sg"></a> [restricted\_sg](#input\_restricted\_sg) | SG to receive restricted service access. If null, no sg will be configured to connect | `string` | `null` | no |

--- a/examples/efs/main.tf
+++ b/examples/efs/main.tf
@@ -1,5 +1,5 @@
 module "efs" {
-  source = "github.com/pbs/terraform-aws-efs-module?ref=0.0.1"
+  source = "github.com/pbs/terraform-aws-efs-module?ref=0.1.0"
 
   organization = var.organization
   environment  = var.environment
@@ -20,10 +20,19 @@ module "service" {
     }
   ]
 
-  efs_sg_ids = module.efs.sgs
-
   organization = var.organization
   environment  = var.environment
   product      = var.product
   repo         = var.repo
+}
+
+module "ecs_to_efs" {
+  source = "github.com/pbs/terraform-aws-sg-rule-module?ref=0.0.1"
+
+  security_group_id = module.efs.sgs[0]
+
+  description = "Allow service ${module.service.name} to access EFS"
+
+  port                     = 2049
+  source_security_group_id = module.service.service_sg
 }

--- a/examples/sgs/main.tf
+++ b/examples/sgs/main.tf
@@ -10,18 +10,18 @@ resource "aws_security_group" "mysql_sg" {
   }
 }
 
-resource "aws_security_group_rule" "mysql_egress" {
-  security_group_id = aws_security_group.mysql_sg.id
-  description       = "Allow all traffic out"
+module "mysql_egress" {
+  source = "github.com/pbs/terraform-aws-sg-rule-module?ref=0.0.1"
+
+  description = "Allow all traffic out"
+
   type              = "egress"
-  protocol          = "-1"
+  security_group_id = aws_security_group.mysql_sg.id
 
-  from_port = 0
-  to_port   = 0
 
-  cidr_blocks = [
-    "0.0.0.0/0",
-  ]
+  port               = 0
+  protocol           = "-1"
+  source_cidr_blocks = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group" "redis_sg" {
@@ -36,18 +36,18 @@ resource "aws_security_group" "redis_sg" {
   }
 }
 
-resource "aws_security_group_rule" "redis_egress" {
-  security_group_id = aws_security_group.redis_sg.id
-  description       = "Allow all traffic out"
+module "redis_egress" {
+  source = "github.com/pbs/terraform-aws-sg-rule-module?ref=0.0.1"
+
+  description = "Allow all traffic out"
+
   type              = "egress"
-  protocol          = "-1"
+  security_group_id = aws_security_group.redis_sg.id
 
-  from_port = 0
-  to_port   = 0
 
-  cidr_blocks = [
-    "0.0.0.0/0",
-  ]
+  port               = 0
+  protocol           = "-1"
+  source_cidr_blocks = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group" "memcached_sg" {
@@ -62,18 +62,18 @@ resource "aws_security_group" "memcached_sg" {
   }
 }
 
-resource "aws_security_group_rule" "memcached_egress" {
-  security_group_id = aws_security_group.memcached_sg.id
-  description       = "Allow all traffic out"
+module "memcached_egress" {
+  source = "github.com/pbs/terraform-aws-sg-rule-module?ref=0.0.1"
+
+  description = "Allow all traffic out"
+
   type              = "egress"
-  protocol          = "-1"
+  security_group_id = aws_security_group.memcached_sg.id
 
-  from_port = 0
-  to_port   = 0
 
-  cidr_blocks = [
-    "0.0.0.0/0",
-  ]
+  port               = 0
+  protocol           = "-1"
+  source_cidr_blocks = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group" "ingress_sg" {
@@ -92,14 +92,43 @@ module "service" {
 
   primary_hosted_zone = var.primary_hosted_zone
 
-  mysql_sg_ids     = [aws_security_group.mysql_sg.id]
-  redis_sg_ids     = [aws_security_group.redis_sg.id]
-  memcached_sg_ids = [aws_security_group.memcached_sg.id]
-
   restricted_sg = aws_security_group.ingress_sg.id
 
   organization = var.organization
   environment  = var.environment
   product      = var.product
   repo         = var.repo
+}
+
+module "ecs_to_mysql" {
+  source = "github.com/pbs/terraform-aws-sg-rule-module?ref=0.0.1"
+
+  security_group_id = aws_security_group.mysql_sg.id
+
+  description = "Allow service ${module.service.name} to access MySQL"
+
+  port                     = 3306
+  source_security_group_id = module.service.service_sg
+}
+
+module "ecs_to_redis" {
+  source = "github.com/pbs/terraform-aws-sg-rule-module?ref=0.0.1"
+
+  security_group_id = aws_security_group.redis_sg.id
+
+  description = "Allow service ${module.service.name} to access Redis"
+
+  port                     = 6379
+  source_security_group_id = module.service.service_sg
+}
+
+module "ecs_to_memcached_sg" {
+  source = "github.com/pbs/terraform-aws-sg-rule-module?ref=0.0.1"
+
+  security_group_id = aws_security_group.memcached_sg.id
+
+  description = "Allow service ${module.service.name} to access Memcached"
+
+  port                     = 11211
+  source_security_group_id = module.service.service_sg
 }

--- a/locals.tf
+++ b/locals.tf
@@ -2,10 +2,6 @@ locals {
   name                                 = var.name != null ? var.name : var.product
   http_port                            = 80
   https_port                           = 443
-  mysql_port                           = 3306
-  redis_port                           = 6379
-  memcached_port                       = 11211
-  efs_port                             = 2049
   route_priority                       = 10
   container_name                       = var.container_name != null ? var.container_name : "app"
   task_family                          = var.task_family != null ? var.task_family : local.name

--- a/optional.tf
+++ b/optional.tf
@@ -289,30 +289,6 @@ variable "private_hosted_zone" {
   type        = string
 }
 
-variable "mysql_sg_ids" {
-  description = "MySQL DB Security group IDs"
-  default     = []
-  type        = set(string)
-}
-
-variable "redis_sg_ids" {
-  description = "Redis Security group IDs"
-  default     = []
-  type        = set(string)
-}
-
-variable "memcached_sg_ids" {
-  description = "Memcached Security group IDs"
-  default     = []
-  type        = set(string)
-}
-
-variable "efs_sg_ids" {
-  description = "EFS Security group IDs"
-  default     = []
-  type        = set(string)
-}
-
 variable "load_balancer_type" {
   description = "Type of load balancer to use. alb, nlb or gateway."
   default     = "application"

--- a/security.tf
+++ b/security.tf
@@ -117,45 +117,6 @@ resource "aws_security_group_rule" "lb_to_service" {
   source_security_group_id = aws_security_group.lb_sg[0].id
 }
 
-resource "aws_security_group_rule" "service_to_mysql" {
-  for_each          = var.mysql_sg_ids
-  security_group_id = each.value
-  description       = "Allow MySQL traffic from the ECS service to the DB"
-  type              = "ingress"
-  protocol          = "tcp"
-
-  from_port = local.mysql_port
-  to_port   = local.mysql_port
-
-  source_security_group_id = aws_security_group.service_sg.id
-}
-
-resource "aws_security_group_rule" "service_to_redis" {
-  for_each          = var.redis_sg_ids
-  security_group_id = each.value
-  description       = "Allow Redis traffic from the ECS service to the cluster"
-  type              = "ingress"
-  protocol          = "tcp"
-
-  from_port = local.redis_port
-  to_port   = local.redis_port
-
-  source_security_group_id = aws_security_group.service_sg.id
-}
-
-resource "aws_security_group_rule" "service_to_memcached" {
-  for_each          = var.memcached_sg_ids
-  security_group_id = each.value
-  description       = "Allow Memcached traffic from the ECS service to the cluster"
-  type              = "ingress"
-  protocol          = "tcp"
-
-  from_port = local.memcached_port
-  to_port   = local.memcached_port
-
-  source_security_group_id = aws_security_group.service_sg.id
-}
-
 resource "aws_security_group_rule" "nlb_service_access_cidr" {
   count             = local.create_nlb_cidr_access_rule ? 1 : 0
   security_group_id = aws_security_group.service_sg.id
@@ -180,32 +141,6 @@ resource "aws_security_group_rule" "nlb_service_access_sg" {
   to_port   = var.container_port
 
   source_security_group_id = var.restricted_sg
-}
-
-resource "aws_security_group_rule" "service_to_efs" {
-  for_each          = var.efs_sg_ids
-  security_group_id = each.value
-  description       = "Allow EFS traffic from the ECS service to the EFS"
-  type              = "ingress"
-  protocol          = "tcp"
-
-  from_port = local.efs_port
-  to_port   = local.efs_port
-
-  source_security_group_id = aws_security_group.service_sg.id
-}
-
-resource "aws_security_group_rule" "efs_service_access_sg" {
-  for_each          = var.efs_sg_ids
-  security_group_id = aws_security_group.service_sg.id
-  description       = "Allow EFS port traffic to the ECS service for specific SGs"
-  type              = "ingress"
-  protocol          = "tcp"
-
-  from_port = local.efs_port
-  to_port   = local.efs_port
-
-  source_security_group_id = each.value
 }
 
 resource "aws_security_group_rule" "user_to_virtual_node_access_cidr" {


### PR DESCRIPTION
This replaces the security group management functionality in this module with the standalone security group rule module that resolves SG rules more agnostically.

This is a breaking change, however, as it requires that consumers replace usage of variables that end in `_sg_ids` with an instance of the https://github.com/pbs/terraform-aws-sg-rule-module module.