### PR TITLE
Using Terraform function `one` to improve stability of module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Using the Repo Source
 
 ```hcl
-github.com/pbs/terraform-aws-ecs-service-module?ref=3.0.0
+github.com/pbs/terraform-aws-ecs-service-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -26,7 +26,7 @@ Integrate this module like so:
 
 ```hcl
 module "service" {
-  source = "github.com/pbs/terraform-aws-ecs-service-module?ref=3.0.0"
+  source = "github.com/pbs/terraform-aws-ecs-service-module?ref=x.y.z"
 
   # Required
   primary_hosted_zone = "example.com"
@@ -47,7 +47,7 @@ module "service" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`3.0.0`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 

--- a/locals.tf
+++ b/locals.tf
@@ -7,22 +7,22 @@ locals {
   task_family                          = var.task_family != null ? var.task_family : local.name
   load_balancer_name                   = var.load_balancer_name != null ? var.load_balancer_name : local.name
   target_group_name                    = var.target_group_name != null ? var.target_group_name : local.name
-  cluster                              = var.cluster != null ? var.cluster : module.cluster[0].name
-  task_def_arn                         = var.task_def_arn != null ? var.task_def_arn : module.task[0].arn
-  vpc_id                               = var.vpc_id != null ? var.vpc_id : data.aws_vpc.vpc[0].id
+  cluster                              = var.cluster != null ? var.cluster : one(module.cluster[*].name)
+  task_def_arn                         = var.task_def_arn != null ? var.task_def_arn : one(module.task[*].arn)
+  vpc_id                               = var.vpc_id != null ? var.vpc_id : one(data.aws_vpc.vpc[*].id)
   public_service                       = !local.create_virtual_node && var.public_service
   subnets                              = var.subnets != null ? var.subnets : var.public_service ? data.aws_subnets.public_subnets[0].ids : data.aws_subnets.private_subnets[0].ids
   lookup_hosted_zone                   = !local.create_virtual_node && local.app_dns_record_count > 0
   lookup_primary_acm_wildcard_cert     = local.lookup_hosted_zone && local.public_service && var.acm_arn == null
-  acm_arn                              = var.acm_arn != null ? var.acm_arn : local.lookup_primary_acm_wildcard_cert ? data.aws_acm_certificate.primary_acm_wildcard_cert[0].arn : null
+  acm_arn                              = var.acm_arn != null ? var.acm_arn : local.lookup_primary_acm_wildcard_cert ? one(data.aws_acm_certificate.primary_acm_wildcard_cert[*].arn) : null
   hosted_zone                          = var.public_service ? var.primary_hosted_zone : var.private_hosted_zone
   null_safe_hosted_zone                = local.hosted_zone == null ? "" : local.hosted_zone
-  hosted_zone_id                       = local.lookup_hosted_zone ? data.aws_route53_zone.hosted_zone[0].zone_id : null
+  hosted_zone_id                       = local.lookup_hosted_zone ? one(data.aws_route53_zone.hosted_zone[*].zone_id) : null
   internal                             = var.internal != null ? var.internal : !var.public_service
   cnames                               = local.create_virtual_node ? [] : var.cnames != null ? var.cnames : [local.name]
   aliases                              = local.create_virtual_node ? [] : var.aliases != null ? var.aliases : ["${local.name}.${local.null_safe_hosted_zone}"]
   app_dns_record_count                 = local.create_lb ? length(local.cnames) : 0
-  domain_name                          = !local.create_lb ? null : local.app_dns_record_count == 0 ? aws_lb.lb[0].dns_name : aws_route53_record.app[0].fqdn
+  domain_name                          = !local.create_lb ? null : local.app_dns_record_count == 0 ? one(aws_lb.lb[*].dns_name) : one(aws_route53_record.app[*].fqdn)
   create_lb_sg                         = local.create_lb && var.load_balancer_type == "application"
   create_http_listeners                = local.create_lb && var.load_balancer_type == "application"
   create_https_listeners               = local.create_lb && var.load_balancer_type == "application" && var.public_service
@@ -38,7 +38,7 @@ locals {
   create_nlb_sg_access_rule            = local.create_lb && !local.create_lb_sg && local.create_sg_access_rule
   create_virtual_node_cidr_access_rule = local.create_virtual_node && local.create_cidr_access_rule
   create_virtual_node_sg_access_rule   = local.create_virtual_node && local.create_sg_access_rule
-  lb_security_groups                   = local.create_lb_sg ? [aws_security_group.lb_sg[0].id] : null
+  lb_security_groups                   = local.create_lb_sg ? [one(aws_security_group.lb_sg[*].id)] : null
   container_protocol                   = var.load_balancer_type == "application" ? var.container_protocol : "TCP"
   healthcheck_protocol                 = var.healthcheck_protocol != null ? var.healthcheck_protocol : local.container_protocol
   healthcheck_matcher                  = var.load_balancer_type == "application" ? var.healthcheck_matcher : null
@@ -48,9 +48,9 @@ locals {
   desired_count                        = var.min_capacity
   deployment_maximum_percent           = local.desired_count == 1 ? 200 : var.deployment_maximum_percent # This is to avoid a bug where deployments can't happen because we can't have 1.5 tasks for a service
   create_virtual_node                  = var.virtual_node != null
-  virtual_node_name                    = local.create_virtual_node ? aws_appmesh_virtual_node.virtual_node[0].name : null
+  virtual_node_name                    = local.create_virtual_node ? one(aws_appmesh_virtual_node.virtual_node[*].name) : null
   create_cloudmap_service              = var.namespace_id != null
-  cloudmap_service_id                  = local.create_cloudmap_service ? aws_service_discovery_service.service[0].id : null
+  cloudmap_service_id                  = local.create_cloudmap_service ? one(aws_service_discovery_service.service[*].id) : null
   namespace                            = var.namespace != null ? var.namespace : local.name
   platform_version                     = var.platform_version != null ? var.platform_version : var.launch_type == "FARGATE" ? "LATEST" : null
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,15 +60,15 @@ output "virtual_node_name" {
 
 output "https_listener_arn" {
   description = "ARN of the HTTPS listener. Useful when adding extra ACM certificates to the listener."
-  value       = local.create_https_listeners ? aws_lb_listener.https[0].arn : null
+  value       = local.create_https_listeners ? one(aws_lb_listener.https[*].arn) : null
 }
 
 output "lb_sg" {
   description = "Load balancer security group"
-  value       = local.create_lb_sg ? aws_security_group.lb_sg[0].id : null
+  value       = local.create_lb_sg ? one(aws_security_group.lb_sg[*].id) : null
 }
 
 output "lb_arn" {
   description = "Load balancer ARN"
-  value       = local.create_lb ? aws_lb.lb[0].arn : null
+  value       = local.create_lb ? one(aws_lb.lb[*].arn) : null
 }

--- a/tests/utilities_ecs_service.go
+++ b/tests/utilities_ecs_service.go
@@ -47,20 +47,7 @@ func testECSService(t *testing.T, variant string) {
 		LockTimeout:  "5m",
 	}
 
-	defer func() {
-		// To ensure that the service is stopped before stopping the cluster.
-		terraformTargetServiceOptions := &terraform.Options{
-			TerraformDir: terraformDir,
-			LockTimeout:  "5m",
-			Targets: []string{
-				"module.service.aws_ecs_service.service",
-				"module.service_v1.aws_ecs_service.service",
-				"module.service_v2.aws_ecs_service.service",
-			},
-		}
-		terraform.Destroy(t, terraformTargetServiceOptions)
-		terraform.Destroy(t, terraformOptions)
-	}()
+	defer terraform.Destroy(t, terraformOptions)
 
 	expectedLogGroup := fmt.Sprintf("/ecs/%s", expectedName)
 


### PR DESCRIPTION
The Terraform documentation for the function `one` indicates that it can be used to avoid the error we're experiencing when trying to destroy resources that use `[0]` to index into a resource that has already been destroyed, but the output is still in state.

https://developer.hashicorp.com/terraform/language/functions/one