### PR TITLE
Pass down `vpc_id` to cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Using the Repo Source
 
 ```hcl
-github.com/pbs/terraform-aws-ecs-service-module?ref=4.0.6
+github.com/pbs/terraform-aws-ecs-service-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -26,7 +26,7 @@ Integrate this module like so:
 
 ```hcl
 module "service" {
-  source = "github.com/pbs/terraform-aws-ecs-service-module?ref=4.0.6"
+  source = "github.com/pbs/terraform-aws-ecs-service-module?ref=x.y.z"
 
   # Required
   primary_hosted_zone = "example.com"
@@ -47,7 +47,7 @@ module "service" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`4.0.6`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -2,6 +2,8 @@ module "cluster" {
   count  = var.cluster == null ? 1 : 0
   source = "github.com/pbs/terraform-aws-ecs-cluster-module?ref=0.0.4"
 
+  vpc_id = local.vpc_id
+
   organization = var.organization
   environment  = var.environment
   product      = var.product


### PR DESCRIPTION
Cluster VPC lookup was failing because `vpc_id` wasn't passed down.